### PR TITLE
fix: key di categorys tidak mengarah ke key yang sesuai

### DIFF
--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -123,7 +123,8 @@ const Controller = {
                 const split = category.split(' ');
                 if (split.includes('Menu')) split.splice(0, 1);
                 const results = Array.from(split).join('-');
-                key = results.toLowerCase();
+                key = $(e).find('a').attr('href').split('/');
+                key = key[key.length - 2];
                 category_list.push({
                     category : category,
                     url : url,


### PR DESCRIPTION
Selamat sore,
Saya menemukan suatu bug yang menyebabkan ada beberapa key di categorys yang tidak mengarah ke key yang seharusnya, dan menyebabkan error 500. 

Pull request ini memperbaiki bug tersebut dengan mengubah metode parsing key dari yang mengambil attribute `data-tracking-value` ke mengambil attribute `href`, sehingga key yang didapat akan mengikuti actual linknya.

Terimakasih sebelumnya, dan mohon maaf mengganggu.